### PR TITLE
adjusted code for allergen icon presence

### DIFF
--- a/app/views/additives/_result.html.erb
+++ b/app/views/additives/_result.html.erb
@@ -10,7 +10,9 @@
             <p class="pt-2 mb-0 fs-5">Information: <%= item.information %></p>
           </div>
           <div class="overflow-container" data-enty-thinner-target="text">
-            <%= image_tag item.icon %>
+            <% if @allergens.include?(item) && item.icon.present? %>
+              <%= image_tag item.icon %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,11 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-
   <body>
     <%= yield %>
   </body>


### PR DESCRIPTION
Adjusted code in _result when doing a search. When search results included an additive (which don't have icons), the display broke, so I adjusted it so that doesn't happen.