### PR TITLE
Additive filter

### DIFF
--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -45,12 +45,12 @@ class ScansController < ApplicationController
       end
 
       @additives = Additive.all
-      @additive_words = @extracted_text.gsub("\n", "").split(/\s+|、/)
-      @matching_additives = []
+      # @additive_words = @extracted_text.gsub("\n", "").split(/\s+|、/)
+      @matching_additives = @additives.select { |additive| text.include?(additive.name) || (text.include?(additive.display_name) if !additive.display_name.nil?)}
 
-      @additive_words.each do |word|
-        @matching_additives.concat(@additives.select { |additive| word.include?(additive.name || additive.display_name) })
-      end
+      # @additive_words.each do |word|
+      #   @matching_additives.concat(@additives.select { |additive| word.include?(additive.name || additive.display_name) })
+      # end
 
       @allergens = Allergen.all
       @allergen_words = @extracted_text.gsub("\n", "").split(/\s+|、/)

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -48,6 +48,7 @@ class ScansController < ApplicationController
       # @additives = Additive.all
       # @additive_words = @extracted_text.gsub("\n", "").split(/\s+|、/)
       @matching_additives = Additive.select { |additive| @extracted_text.include?(additive.name) || (@extracted_text.include?(additive.display_name) unless additive.display_name.nil?)}
+      # @matching_additives = Additive.select { |additive| @extracted_text.include?(additive.display_name || additive.name)}
 
       # @additive_words.each do |word|
       #   @matching_additives.concat(@additives.select { |additive| word.include?(additive.name || additive.display_name) })

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -34,6 +34,7 @@ class ScansController < ApplicationController
     @image_url = "https://res.cloudinary.com/dvqsmda6p/image/upload/v1698067820/development/#{@scan.image_url.key}"
 
     if @image_url.present?
+      # consider running text extraction and saving the extracted text in database item, so you don't have to call the API everytime the page is refreshed
       google_vision_service = GoogleVisionService.new(@image_url)
       @extracted_text = google_vision_service.extract_text
 
@@ -44,9 +45,9 @@ class ScansController < ApplicationController
         format.html
       end
 
-      @additives = Additive.all
+      # @additives = Additive.all
       # @additive_words = @extracted_text.gsub("\n", "").split(/\s+|、/)
-      @matching_additives = @additives.select { |additive| text.include?(additive.name) || (text.include?(additive.display_name) if !additive.display_name.nil?)}
+      @matching_additives = Additive.select { |additive| @extracted_text.include?(additive.name) || (@extracted_text.include?(additive.display_name) unless additive.display_name.nil?)}
 
       # @additive_words.each do |word|
       #   @matching_additives.concat(@additives.select { |additive| word.include?(additive.name || additive.display_name) })

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[7.0].define(version: 2023_11_05_025330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,12 +70,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_05_025330) do
     t.datetime "updated_at", null: false
     t.index ["additive_id"], name: "index_ingredients_on_additive_id"
     t.index ["allergen_id"], name: "index_ingredients_on_allergen_id"
-  end
-
-  create_table "results", force: :cascade do |t|
-    t.text "text"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "scans", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,6 +30,7 @@ CSV.foreach(csv_file, headers: true) do |row|
     purpose: row['purpose'],
     information: row['information'],
     danger_level: row['danger_level'],
+    display_name: row['display_name'],
     url: row['url']
   )
 end


### PR DESCRIPTION
Two issues was found.

1. The seed file did not take in account the added column of `display_name`. Therefore when you seed, none of the database entries has `display_name`.
2. Filter logics was almost correct
- `display_name` logic failed due to it not being in the database
- Line 51 is the minor change to your code to make it work in a way that ruby will check for `display_name` first, if it is `nil` it will check for `name`, but this also doesn't work because if there is a display_name, it will not check the original name
- therefore the final code of Line 50 will check for both `name` and `display_name` if `display_name` is not nil

** suggested change: turn `display_name` to `searchable_names`
make `searchable_names` into an array including both original name and optional name
filter based on the array.

This way there can be more than 2 names
(currently, there can only be name or display_name, and if there are more than one display_name, you won't be able to searching using the 3rd name)

It will then become something like
`Additive.select {  |additive| additive.searchable_names.any? { |name| @extracted_text.include?(name) } }`
